### PR TITLE
Enable SSE2 intrinsics code and Elbrus CPU support

### DIFF
--- a/lalapps/src/pulsar/GCT/Makefile.am
+++ b/lalapps/src/pulsar/GCT/Makefile.am
@@ -6,7 +6,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/pulsar/Fstatistic -I$(top_srcdir)/src/pulsar/
 
 bin_PROGRAMS = lalapps_HierarchSearchGCT
 check_PROGRAMS =
-EXTRA_PROGRAMS = eah_HierarchSearchGCT \
+EXTRA_PROGRAMS = eah_HierarchSearchGCT eah_HierarchSearchGCT_SSE2 eah_HierarchSearchGCT_SSE2_NOOPT eah_HierarchSearchGCT_SSE2_INTRIN \
 	         lalapps_HierarchSearchGCT_SSE2 lalapps_HierarchSearchGCT_SSE2_NONC
 
 EAHSources = hs_boinc_extras.c hs_boinc_options.cpp win_lib.cpp
@@ -27,14 +27,33 @@ lalapps_HierarchSearchGCT_SSE2_NONC_CFLAGS = $(AM_CFLAGS) -msse -msse2 -mfpmath=
 
 
 eah_HierarchSearchGCT_SOURCES = $(HSGCTSources) $(EAHSources)
+eah_HierarchSearchGCT_SSE2_SOURCES = $(HSGCTSources) $(EAHSources)
+eah_HierarchSearchGCT_SSE2_NOOPT_SOURCES = $(HSGCTSources) $(EAHSources)
+eah_HierarchSearchGCT_SSE2_INTRIN_SOURCES = $(HSGCTSources) $(EAHSources)
+
 eah_HierarchSearchGCT_CPPFLAGS = $(AM_CPPFLAGS) -DEAH_BOINC -DHS_OPTIMIZATION -DHIERARCHSEARCHGCT
+eah_HierarchSearchGCT_SSE2_CPPFLAGS = $(AM_CPPFLAGS) -DEAH_BOINC -DHS_OPTIMIZATION -DHIERARCHSEARCHGCT -DGC_SSE2_OPT 
+eah_HierarchSearchGCT_SSE2_NOOPT_CPPFLAGS = $(AM_CPPFLAGS) -DEAH_BOINC -DHS_OPTIMIZATION -DHIERARCHSEARCHGCT -DGC_SSE2_OPT -DEXP_NO_ASM
+eah_HierarchSearchGCT_SSE2_INTRIN_CPPFLAGS = $(AM_CPPFLAGS) -DEAH_BOINC -DHS_OPTIMIZATION -DHIERARCHSEARCHGCT -DGC_SSE2_OPT -DEXP_USE_INTRIN
+
 # this shouldn't harm - it just prefers libraries in the build directory over e.g. system ones
 eah_HierarchSearchGCT_LDFLAGS = -L. $(AM_LDFLAGS)
+eah_HierarchSearchGCT_SSE2_LDFLAGS = -L. $(AM_LDFLAGS)
+eah_HierarchSearchGCT_SSE2_NOOPT_LDFLAGS = -L. $(AM_LDFLAGS)
+eah_HierarchSearchGCT_SSE2_INTRIN_LDFLAGS = -L. $(AM_LDFLAGS)
+
 # RELEASE_DEPS contains additional dependencies of the E@H build
 # items in there should have rules listed below to create them
 # the idea is to increase compatibility of E@H applications by linking these libs statically
 eah_HierarchSearchGCT_DEPENDENCIES = $(RELEASE_DEPS)
+eah_HierarchSearchGCT_SSE2_DEPENDENCIES = $(RELEASE_DEPS)
+eah_HierarchSearchGCT_SSE2_NOOPT_DEPENDENCIES = $(RELEASE_DEPS)
+eah_HierarchSearchGCT_SSE2_INTRIN_DEPENDENCIES = $(RELEASE_DEPS)
+
 eah_HierarchSearchGCT_LDADD = $(LDADD) $(RELEASE_LDADD)
+eah_HierarchSearchGCT_SSE2_LDADD = $(LDADD) $(RELEASE_LDADD)
+eah_HierarchSearchGCT_SSE2_NOOPT_LDADD = $(LDADD) $(RELEASE_LDADD)
+eah_HierarchSearchGCT_SSE2_INTRIN_LDADD = $(LDADD) $(RELEASE_LDADD)
 
 libstdc++.a:
 	cp -f `$(CC) -print-file-name=$@` $@

--- a/lalapps/src/pulsar/GCT/gc_hotloop_sse2.h
+++ b/lalapps/src/pulsar/GCT/gc_hotloop_sse2.h
@@ -21,6 +21,10 @@ extern void *__mingw_aligned_realloc(void *ptr, size_t size, size_t align);
 
 #include <stdlib.h>
 
+#if (defined (__e2k__) && defined (__SSE2__)) || defined (EXP_USE_INTRIN)
+#include <xmmintrin.h>
+#endif
+
 #define ALFree free
 
 static void *ALRealloc(void *ptr, size_t size);
@@ -79,7 +83,66 @@ void gc_hotloop_2Fmax_tracking (REAL4 * fgrid2F, REAL4 * fgrid2Fmax, UINT4 * fgr
 
 #else
 
+#if defined (__e2k__) || defined (EXP_USE_INTRIN)
 
+    __m128 *pxmm2, *pxmm3, *pxmm4, *pxmm5, xmm7[4], xmm8[4];
+
+    pxmm2 = (__m128*)cgrid2F;
+    pxmm3 = (__m128*)fgrid2F;
+    pxmm4 = (__m128*)fgrid2Fmax;
+    pxmm5 = (__m128*)fgrid2FmaxIdx;
+    xmm7[0] = _mm_cmple_ps(pxmm4[0], pxmm2[0]);
+    xmm7[1] = _mm_cmple_ps(pxmm4[1], pxmm2[1]);
+    xmm7[2] = _mm_cmple_ps(pxmm4[2], pxmm2[2]);
+    xmm7[3] = _mm_cmple_ps(pxmm4[3], pxmm2[3]);
+    xmm8[0] = _mm_xor_ps(*(__m128*)V1111, xmm7[0]);
+    xmm8[1] = _mm_xor_ps(*(__m128*)V1111, xmm7[1]);
+    xmm8[2] = _mm_xor_ps(*(__m128*)V1111, xmm7[2]);
+    xmm8[3] = _mm_xor_ps(*(__m128*)V1111, xmm7[3]);
+    pxmm3[0] = _mm_add_ps(pxmm2[0], pxmm3[0]);
+    pxmm3[1] = _mm_add_ps(pxmm2[1], pxmm3[1]);
+    pxmm3[2] = _mm_add_ps(pxmm2[2], pxmm3[2]);
+    pxmm3[3] = _mm_add_ps(pxmm2[3], pxmm3[3]);
+    pxmm4[0] = _mm_or_ps (_mm_and_ps(xmm7[0], pxmm2[0]       ), _mm_and_ps(xmm8[0], pxmm4[0]));
+    pxmm5[0] = _mm_or_ps (_mm_and_ps(xmm7[0], *(__m128*)VIIII), _mm_and_ps(xmm8[0], pxmm5[0]));
+    pxmm4[1] = _mm_or_ps (_mm_and_ps(xmm7[1], pxmm2[1]       ), _mm_and_ps(xmm8[1], pxmm4[1]));
+    pxmm5[1] = _mm_or_ps (_mm_and_ps(xmm7[1], *(__m128*)VIIII), _mm_and_ps(xmm8[1], pxmm5[1]));
+    pxmm4[2] = _mm_or_ps (_mm_and_ps(xmm7[2], pxmm2[2]       ), _mm_and_ps(xmm8[2], pxmm4[2]));
+    pxmm5[2] = _mm_or_ps (_mm_and_ps(xmm7[2], *(__m128*)VIIII), _mm_and_ps(xmm8[2], pxmm5[2]));
+    pxmm4[3] = _mm_or_ps (_mm_and_ps(xmm7[3], pxmm2[3]       ), _mm_and_ps(xmm8[3], pxmm4[3]));
+    pxmm5[3] = _mm_or_ps (_mm_and_ps(xmm7[3], *(__m128*)VIIII), _mm_and_ps(xmm8[3], pxmm5[3]));
+
+
+/* Original unoptimized version */
+
+/*    register __m128 xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+
+    xmm0 = *(__m128*)VIIII;
+    xmm1 = *(__m128*)V1111;
+
+    for(int i = 0; i < 0x40; i += 0x10)
+    {
+        xmm2 = *(__m128*)((char*)cgrid2F      +i);
+        xmm3 = *(__m128*)((char*)fgrid2F      +i);
+        xmm4 = *(__m128*)((char*)fgrid2Fmax   +i);
+        xmm5 = *(__m128*)((char*)fgrid2FmaxIdx+i);
+        xmm7 = xmm4;
+        xmm7 = _mm_cmple_ps(xmm7, xmm2);
+        xmm3 = _mm_add_ps(xmm2, xmm3);
+        *(__m128*)((char*)fgrid2F      +i) = xmm3;
+        xmm6 = xmm0;
+        xmm2 = _mm_and_ps(xmm7, xmm2);
+        xmm6 = _mm_and_ps(xmm7, xmm6);
+        xmm7 = _mm_xor_ps(xmm1, xmm7);
+        xmm4 = _mm_and_ps(xmm7, xmm4);
+        xmm5 = _mm_and_ps(xmm7, xmm5);
+        xmm4 = _mm_or_ps (xmm2, xmm4);
+        xmm5 = _mm_or_ps (xmm6, xmm5);
+        *(__m128*)((char*)fgrid2Fmax   +i) = xmm4;
+        *(__m128*)((char*)fgrid2FmaxIdx+i) = xmm5;
+    } */
+
+#else
     __asm __volatile (
          "MOVAPS %[Vk],%%xmm0 \n\t"
          "MOVAPS %[V1],%%xmm1 \n\t"
@@ -197,7 +260,6 @@ void gc_hotloop_2Fmax_tracking (REAL4 * fgrid2F, REAL4 * fgrid2Fmax, UINT4 * fgr
          "MOVAPS  %%xmm5,0x30(%[fg2FmaxIdx]) \n\t"
 
 
-
 /*  ---------------------------------------------------*/
 :
       /* output */
@@ -222,6 +284,7 @@ void gc_hotloop_2Fmax_tracking (REAL4 * fgrid2F, REAL4 * fgrid2Fmax, UINT4 * fgr
 
     ) ;
 
+#endif
 
     fgrid2F+=16;
     cgrid2F+=16;
@@ -276,6 +339,53 @@ for(ifreq_fg=0 ; ifreq_fg +16 < length; ifreq_fg+=16 ) {
   }
 
 #else
+
+#if defined (__e2k__) || defined (EXP_USE_INTRIN)
+
+    register __m128 xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+
+    xmm3 = *(__m128*)fgrid2F;
+    xmm2 = *(__m128*)cgrid2F;
+    xmm4 = *(__m128*)((char*)cgrid2F+0x10);
+    xmm5 = *(__m128*)((char*)cgrid2F+0x20);
+    xmm6 = *(__m128*)((char*)cgrid2F+0x30);
+    xmm7 = *(__m128*)VTTTT;
+
+    xmm3 = _mm_add_ps(xmm2, xmm3);
+    xmm1 = *(__m128*)fgridnc;
+    *(__m128*)fgrid2F = xmm3;
+    xmm3 = xmm7;
+    xmm3 = _mm_cmple_ps(xmm3, xmm2);
+
+    xmm2 = *(__m128*)((char*)fgrid2F+0x10);
+    xmm2 = _mm_add_ps(xmm4, xmm2);
+    *(__m128*)((char*)fgrid2F+0x10) = xmm2;
+    xmm0 = xmm7;
+    xmm0 = _mm_cmple_ps(xmm0, xmm4);
+
+    xmm3 = (__m128)_mm_packs_epi32((__m128i)xmm3, (__m128i)xmm0);
+
+    xmm4 = *(__m128*)((char*)fgrid2F+0x20);
+    xmm4 = _mm_add_ps(xmm4, xmm5);
+    *(__m128*)((char*)fgrid2F+0x20) = xmm4;
+    xmm4 = xmm7;
+    xmm4 = _mm_cmple_ps(xmm4, xmm5);
+
+    xmm2 = *(__m128*)((char*)fgrid2F+0x30);
+    xmm2 = _mm_add_ps(xmm2, xmm6);
+    *(__m128*)((char*)fgrid2F+0x30) = xmm2;
+    xmm0 = xmm7;
+    xmm0 = _mm_cmple_ps(xmm0, xmm6);
+
+    xmm4 = (__m128)_mm_packs_epi32((__m128i)xmm4, (__m128i)xmm0);
+    xmm3 = (__m128)_mm_packs_epi16((__m128i)xmm3, (__m128i)xmm4);
+
+    xmm1 = (__m128)_mm_sub_epi8((__m128i)xmm1, (__m128i)xmm3);
+
+    *(__m128*)fgridnc = xmm1;
+
+#else
+
     __asm __volatile (
          "MOVUPS  (%[cg2F]),%%xmm2 \n\t"  /* load coarse grid values, possibly unaligned */
          "MOVAPS  (%[fg2F]),%%xmm3 \n\t"
@@ -359,7 +469,10 @@ for(ifreq_fg=0 ; ifreq_fg +16 < length; ifreq_fg+=16 ) {
 
     ) ;
 
+#endif
+
 #endif // EXP_No_ASM
+
     fgrid2F+=16;
     cgrid2F+=16;
     fgridnc+=16;
@@ -393,6 +506,34 @@ for( ifreq_fg=0 ; ifreq_fg +16 < length; ifreq_fg+=16 ) {
   }
 
 #else
+
+#if defined (__e2k__) || defined (EXP_USE_INTRIN)
+
+    register __m128 xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+
+    xmm3 = *(__m128*)fgrid2F;
+    xmm2 = *(__m128*)cgrid2F;
+    xmm4 = *(__m128*)((char*)cgrid2F+0x10);
+    xmm5 = *(__m128*)((char*)cgrid2F+0x20);
+    xmm6 = *(__m128*)((char*)cgrid2F+0x30);
+
+    xmm3 = _mm_add_ps(xmm2, xmm3);
+    *(__m128*)fgrid2F = xmm3;
+
+    xmm2 = *(__m128*)((char*)fgrid2F+0x10);
+    xmm2 = _mm_add_ps(xmm4, xmm2);
+    *(__m128*)((char*)fgrid2F+0x10) = xmm2;
+
+    xmm4 = *(__m128*)((char*)fgrid2F+0x20);
+    xmm4 = _mm_add_ps(xmm5, xmm4);
+    *(__m128*)((char*)fgrid2F+0x20) = xmm4;
+
+    xmm2 = *(__m128*)((char*)fgrid2F+0x30);
+    xmm2 = _mm_add_ps(xmm6, xmm2);
+    *(__m128*)((char*)fgrid2F+0x30) = xmm2;
+
+#else
+
     __asm __volatile (
          "MOVUPS  (%[cg2F]),%%xmm2 \n\t"  /* load coarse grid values, possibly unaligned */
          "MOVAPS  (%[fg2F]),%%xmm3 \n\t"
@@ -437,7 +578,10 @@ for( ifreq_fg=0 ; ifreq_fg +16 < length; ifreq_fg+=16 ) {
 
     ) ;
 
+#endif
+
 #endif // EXP_No_ASM
+
     fgrid2F+=16;
     cgrid2F+=16;
 


### PR DESCRIPTION
I can't make pull requests to main LIGO git (https://git.ligo.org/lscsoft/lalsuite), so I make a pull request here. It is surely pushable to the main repository though.

In GCT app, there is SSE code written in x86_64 assembler; but vector extensions are available on some other CPUs, like Elbrus-8S and Elbrus-8SV (https://en.wikipedia.org/wiki/Elbrus-8S). So I added an implementation based on compiler instrinsics (and some specific targets for eah_HierarchSearchGCT binary to make this implementation buildable without modifying the Makefile), to make E@H application be able to be built and run efficiently (I achiveved about 3 times performance increase) on platforms that do not support x86_64 assembler (especially Elbrus).